### PR TITLE
MapController: keyboard navigation

### DIFF
--- a/Atlas/Atlas.cpp
+++ b/Atlas/Atlas.cpp
@@ -77,7 +77,7 @@ void Atlas::initAll()
     initDataStructure();
 
 	emit sendNowInitName(tr("Initializing camera"));
-	resetMainManipulator();
+	resetCamera();
 
 	initPlugins();
 
@@ -98,7 +98,7 @@ void Atlas::initCore()
 
 	connect(_dataManager, &DataManager::loadingProgress, this, &AtlasMainWindow::loadingProgress);
 	connect(_dataManager, &DataManager::loadingDone, this, &AtlasMainWindow::loadingDone);
-	connect(_dataManager, &DataManager::resetMainManipulator, this, &Atlas::resetMainManipulator);
+	connect(_dataManager, &DataManager::resetCamera, this, &Atlas::resetCamera);
 
     emit sendNowInitName(tr("Initializing viewer"));
 	_mainViewerWidget = new ViewerWidget(_root, 0, 0, 1280, 1024, osgViewer::ViewerBase::SingleThreaded);
@@ -178,11 +178,19 @@ void Atlas::initDataStructure()
     _dataManager->registerDataRoots(_root);
 }
 
-void Atlas::resetMainManipulator()
+void Atlas::resetCamera()
 {
-	_mainViewerWidget->resetMainManipulator(_dataManager->getCenterNode());
+    MapController* manipulator = _mainViewerWidget->getManipulator();
+    if (manipulator == NULL)
+    {
+        // Init a manipulator if not inited yet
+        manipulator = new MapController(_dataRoot);
+        _mainViewerWidget->getMainView()->setCameraManipulator(manipulator);
+        manipulator->setAutoComputeHomePosition(false);
 
-	MapController* manipulator = _mainViewerWidget->getManipulator();
+        manipulator->setCenterIndicator(_mainViewerWidget->createCameraIndicator());
+    }
+	_mainViewerWidget->resetCamera(_mapNode[0]);
 
 	connect(_dataManager, SIGNAL(moveToNode(const osg::Node*, double)), 
 		manipulator, SLOT(fitViewOnNode(const osg::Node*, double)),

--- a/Atlas/Atlas.h
+++ b/Atlas/Atlas.h
@@ -55,7 +55,7 @@ public slots:
 	void about();
 
 	// View related slots
-	void resetMainManipulator();
+	void resetCamera();
 
 signals:
 	// For splash screen

--- a/core/DataManager/DataManager.cpp
+++ b/core/DataManager/DataManager.cpp
@@ -32,7 +32,6 @@ DataManager::DataManager(SettingsManager* settingsManager, QObject* parent /*= N
 	, _countLoadingData(0)
 	, _settingsManager(settingsManager)
 	//, _featureStyleDlg(NULL)
-	, _activatedNode(NULL)
 {
 	initDataTree();
 	setupUi();
@@ -185,7 +184,7 @@ void DataManager::setupUi()
 	//rotateModelAction->setText(tr("Rotate"));
 	//rotateModelAction->setToolTip(tr("Rotate model"));
 
-	connect(resetViewAction, SIGNAL(triggered()), this, SIGNAL(resetMainManipulator()));
+	connect(resetViewAction, SIGNAL(triggered()), this, SIGNAL(resetCamera()));
 	
 	//connect(showAttributeTableAction, SIGNAL(triggered()), this, SLOT(showAttributeTableSlot()));
 	//connect(showMetatDataAction, SIGNAL(triggered()), this, SLOT(showMetaDataSlot()));
@@ -315,32 +314,15 @@ void DataManager::registerDataRoots(osg::Group* root)
 
 void DataManager::setCenterNode(osg::Node* node)
 {
-	_centerNode = node;
-
-	emit moveToNode(_centerNode, 0);
+	emit moveToNode(node, 0);
 
 	emit loadingDone();
-}
-
-void DataManager::setActivatedNode(osg::Node* node)
-{
-	_activatedNode = node;
 }
 
 const osgEarth::GeoExtent* DataManager::getExtent(const QString& name)
 {
 	DataRecord* record = _nodeTree->getRecord(name);
 	return record ? record->extent() : NULL;
-}
-
-osg::Node* DataManager::getCenterNode()
-{
-	return _centerNode.get();
-}
-
-osg::Node* DataManager::getActivatedNode()
-{
-	return _activatedNode.get();
 }
 
 QList<QTreeWidgetItem*> DataManager::getSelectedItems()

--- a/core/DataManager/DataManager.h
+++ b/core/DataManager/DataManager.h
@@ -69,8 +69,6 @@ public:
 
 	// Getters
 	const osgEarth::GeoExtent* getExtent(const QString& name);
-	osg::Node* getCenterNode();
-	osg::Node* getActivatedNode();
 	QList<QTreeWidgetItem*> getSelectedItems();
 
 	QMap<QString, QVector<attrib>>& getAttributeList();
@@ -114,7 +112,7 @@ signals:
 	void loadingProgress(int);
 	void loadingDone();
 	void requestContextMenu(QMenu*, QTreeWidgetItem*);
-	void resetMainManipulator();
+	void resetCamera();
 	void showDataAttributes(QString);
 
 private:
@@ -145,10 +143,6 @@ private:
 	QMap<QString, QVector<attrib>> _attributeLists;
 	QMap<QString, QVector<feature>> _featureTables;
 	QMap<QString, QStringList> _featureFieldList;
-
-	// Scene structure reference
-	osg::ref_ptr<osg::Node> _activatedNode;
-	osg::ref_ptr<osg::Node> _centerNode;
 
 	// Data loading
 	//ModelLayerManager* _modellyermanager;

--- a/core/MapController/MapController.h
+++ b/core/MapController/MapController.h
@@ -3,6 +3,8 @@
 
 #include "MapController_global.h"
 
+#include <QMap>
+
 #include <QObject>
 #include <osgGA/OrbitManipulator>
 #include <osgViewer/View>
@@ -25,7 +27,7 @@ class MAPCONTROLLER_EXPORT MapController :public QObject, public osgGA::OrbitMan
 	Q_OBJECT
 
 public:
-	MapController();
+	MapController(osg::ref_ptr<osg::Node> dataRoot);
 
 	// Event handler that is called every event traversal
 	virtual bool handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& us) override;
@@ -49,9 +51,20 @@ protected:
 	// Rotate function defined by OrbitManipulator
 	virtual void rotateWithFixedVertical(const float dx, const float dy) override;
 
+    // Keyboard function defined by OrbitManipulator
+    virtual bool handleKeyDown(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& us) override;
+
+    // Keyboard function defined by OrbitManipulator
+    virtual bool handleKeyUp(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& us) override;
+
+    // Action that make sure the rotation center is intersected with the scene
+    virtual void stickToScene();
+
+    void updateDriveDirection();
+
 public slots:
 	// Begin or stop predefined movement
-	void updateTravelrole(bool isTravel);
+	void enableAnimation(bool enabled);
 
 	// Begin or stop screen saving movement
 	void screenSaving(bool on);
@@ -68,10 +81,11 @@ public slots:
 protected slots:
 	void screenSaversMovement();
 	void flyingMovement();
+    void drivingMovement();
 
 private:
 	// Movement switches
-	bool _isTraveling;
+	bool _inAnimation;
 	bool _isFlying;
 	bool _isScreenSaving;
 
@@ -99,6 +113,17 @@ private:
 
 	osg::ref_ptr<osg::PositionAttitudeTransform> _centerIndicator;
 	osg::ref_ptr<osgViewer::View> _view;
+
+    // Driver mode
+    bool _isDriving;
+    osg::Vec3 _driveDirection;
+    osg::Vec3 _front;
+    osg::Vec3 _right;
+    double _driveSpeed;
+    QMap<int, bool> _keyPressed;
+
+    // Data root to stick to
+    osg::ref_ptr<osg::Node> _dataRoot;
 };
 
 #endif

--- a/core/ViewerWidget/ViewerWidget.cpp
+++ b/core/ViewerWidget/ViewerWidget.cpp
@@ -236,18 +236,8 @@ osg::ref_ptr<osg::Camera> ViewerWidget::createLegendHud(QString titleString, QVe
 	return hudCamera;
 }
 
-void ViewerWidget::resetMainManipulator(osg::ref_ptr<osg::Node> centerNode)
+void ViewerWidget::resetCamera(osg::ref_ptr<osg::Node> centerNode)
 {
-	if (_mainView->getCameraManipulator() == NULL)
-	{
-		// Init a manipulator if not inited yet
-		_mainManipulator = new MapController();
-		_mainView->setCameraManipulator(_mainManipulator);
-		_mainManipulator->setAutoComputeHomePosition(false);
-
-		_mainManipulator->setCenterIndicator(createCameraIndicator());
-	}
-
 	if (centerNode.valid())
 	{
 		(dynamic_cast<MapController*>(_mainView->getCameraManipulator()))->fitViewOnNode(centerNode, 0);
@@ -256,7 +246,7 @@ void ViewerWidget::resetMainManipulator(osg::ref_ptr<osg::Node> centerNode)
 
 MapController * ViewerWidget::getManipulator()
 {
-	return _mainManipulator;
+	return dynamic_cast<MapController*>(_mainView->getCameraManipulator());
 }
 
 osg::ref_ptr<osg::PositionAttitudeTransform> ViewerWidget::createCameraIndicator()

--- a/core/ViewerWidget/ViewerWidget.h
+++ b/core/ViewerWidget/ViewerWidget.h
@@ -46,7 +46,7 @@ public:
 	 MapController* getManipulator();
 
 	 // Reset camera manipulator to the default position
-	 void resetMainManipulator(osg::ref_ptr<osg::Node> centerNode);
+	 void resetCamera(osg::ref_ptr<osg::Node> centerNode);
 
 	// Add a widget to the viewer layout at specified position
 	void setWidgetInLayout(QWidget* widget, int row, int column, bool visible = true);
@@ -66,6 +66,9 @@ public:
 	// Viewer paint event, it is called automatically every UI update
 	virtual void paintEvent(QPaintEvent* event) override;
 
+    // An indicator at the center of the scene
+    osg::ref_ptr<osg::PositionAttitudeTransform> createCameraIndicator();
+
 public slots:
 	void setMouseStyle(unsigned styleshape);
 	void stopRendering();
@@ -73,9 +76,6 @@ public slots:
 	void setFrameRate(int FPS);
 
 protected:
-	// An indicator at the center of the scene
-	osg::ref_ptr<osg::PositionAttitudeTransform> createCameraIndicator();
-
 	// A compass that's rendered as an hud
 	void initCompass(osg::Group* root);
 

--- a/plugins/InsolationAnalysis/InsolationAnalysis.cpp
+++ b/plugins/InsolationAnalysis/InsolationAnalysis.cpp
@@ -351,21 +351,13 @@ void InsolationAnalysis::toggle(bool checked)
 {
     if (checked)
     {
-        osg::Node* activenode = _dataManager->getActivatedNode();
-        osg::Node* selectNode = NULL;
-
-        if (activenode)
-        {
-            selectNode = findNodeInNode(activenode->getName(), _dataRoot);
-        }
-
-        if (!selectNode)
+        if (!_selectedNode)
         {
             QMessageBox::warning(_mainWindow, tr("Notice:"), tr("Please select a model first."), QMessageBox::Ok);
             _action->toggle();
             return;
         }
-        toggleTileSelectDialog(selectNode, true);
+        toggleTileSelectDialog(_selectedNode, true);
 
     }
     else

--- a/plugins/OrthoMap/OrthoMap.cpp
+++ b/plugins/OrthoMap/OrthoMap.cpp
@@ -9,10 +9,10 @@
 #include <osgSim/OverlayNode>
 
 #include "SaveOrthoProjDialog.h"
-#include <DataManager/DataManager.h>
 #include <DataManager/FindNode.hpp>
 
 OrthoMap::OrthoMap()
+    : _selectedNode(nullptr)
 {
 	_pluginName = tr("Orthographic Map");
 	_pluginCategory = "Edit";
@@ -111,10 +111,10 @@ void OrthoMap::toggle(bool checked)
 		else
 			QMessageBox::critical(NULL, tr("Error"), tr("OrthoMap plugin received from invalid sender!"));
 
-		if (_dataManager->getCenterNode() == NULL)
+		if (_selectedNode == NULL)
 			QMessageBox::critical(NULL, tr("Error"), tr("No active model selected!"));
 		else
-			setupWorkingDialog(_dataManager->getCenterNode());
+			setupWorkingDialog(_selectedNode);
 
 		action->toggle();
 	}

--- a/plugins/OrthoMap/OrthoMap.h
+++ b/plugins/OrthoMap/OrthoMap.h
@@ -28,6 +28,7 @@ public slots:
 	virtual void toggle(bool checked) override;
 
 protected:
+    osg::Node* _selectedNode;
 	SaveOrthoProjDialog::ProjectionMode _mode;
 	SaveOrthoProjDialog* _saveDialog;
 	QAction* _orthoModelAction;


### PR DESCRIPTION
1. Use direction keys on keyboard to navigate
2. Adjust the api of MapController slightly
3. Remove _activatedNode and _centerNode from DataManager